### PR TITLE
fix: testing_zh.md dev dependencies reference

### DIFF
--- a/src/tutorial/testing_zh.md
+++ b/src/tutorial/testing_zh.md
@@ -289,7 +289,7 @@ Rust 处理项目的方式非常灵活，尽早地考虑清楚哪些功能要放
 它们只会在开发时被使用到，而使用时则不会。
 
 ```toml
-{{#include testing/Cargo.toml:11:13}}
+{{#include testing/Cargo.toml:16:19}}
 ```
 
 [`assert_cmd`]: https://docs.rs/assert_cmd

--- a/src/tutorial/testing_zh.md
+++ b/src/tutorial/testing_zh.md
@@ -289,7 +289,7 @@ Rust 处理项目的方式非常灵活，尽早地考虑清楚哪些功能要放
 它们只会在开发时被使用到，而使用时则不会。
 
 ```toml
-{{#include testing/Cargo.toml:16:19}}
+{{#include testing/Cargo.toml:16:18}}
 ```
 
 [`assert_cmd`]: https://docs.rs/assert_cmd
@@ -320,7 +320,7 @@ Rust 处理项目的方式非常灵活，尽早地考虑清楚哪些功能要放
 让我们把它添加到 `Cargo.toml` 的 `dev-dependencies` 中。
 
 ```toml
-{{#include testing/Cargo.toml:14}}
+{{#include testing/Cargo.toml:19}}
 ```
 
 [`assert_fs`]: https://docs.rs/assert_fs


### PR DESCRIPTION
下面两个示例的引用不正确，修复了下：

- [1.6. 测试](https://suibianxiedianer.github.io/rust-cli-book-zh_CN/tutorial/testing_zh.html) 下的 [通过运行 CLI 程序来测试它们](https://suibianxiedianer.github.io/rust-cli-book-zh_CN/tutorial/testing_zh.html#%E9%80%9A%E8%BF%87%E8%BF%90%E8%A1%8C-cli-%E7%A8%8B%E5%BA%8F%E6%9D%A5%E6%B5%8B%E8%AF%95%E5%AE%83%E4%BB%AC) 里的 `dev dependencies` 。
- [生成测试文件](https://suibianxiedianer.github.io/rust-cli-book-zh_CN/tutorial/testing_zh.html#%E7%94%9F%E6%88%90%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6) 的 `assert_fs`。